### PR TITLE
Add new recall sources and VIN lookup endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ PG_URL=postgresql+psycopg2://recallguard:recallguard@localhost/recallguard
 PG_USER=recallguard
 SENDGRID_API_KEY=
 SLACK_WEBHOOK_URL=
+VIN_DECODER_URL=https://vpic.nhtsa.dot.gov/api/vehicles/DecodeVinValuesExtended/{vin}?format=json
+NHTSA_RECALL_URL=https://api.nhtsa.gov/recalls/recallcampaigns?vin={vin}
 VERCEL_ORG_ID=
 VERCEL_PROJECT_ID=
 VERCEL_TOKEN=

--- a/README.md
+++ b/README.md
@@ -95,4 +95,20 @@ The project ships with a GitHub Actions workflow that builds Docker images and d
 - `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
 - `PG_URL`, `JWT_SECRET`, `SENDGRID_API_KEY`, `SLACK_WEBHOOK_URL`
 
+## Additional Recall Sources
+
+The ingest pipeline also fetches drug and device enforcement data from openFDA:
+
+- `https://api.fda.gov/drug/enforcement.json?search=status:"Ongoing"&limit=100`
+- `https://api.fda.gov/device/enforcement.json?search=status:"Ongoing"&limit=100`
+
+Vehicle owners can look up recalls by VIN via the authenticated endpoint:
+
+```
+GET /api/recalls/vin/<vin>
+```
+
+Provide a 17 character alphanumeric VIN. The route returns any matching recalls
+but does not automatically generate alerts.
+
 

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -10,6 +10,7 @@ from .notifications import bp as notifications_bp
 from backend.utils.logging import configure_logging
 from .recalls import fetch_all
 from backend.utils.refresh import refresh_recalls
+from backend.utils.nhtsa_vin import get_recalls_for_vin
 from .alerts import check_user_items, generate_summary
 from backend.db import init_db
 from backend.utils import db as db_utils
@@ -30,102 +31,114 @@ def create_app() -> Flask:
     configure_logging()
     init_db()
 
-    @app.post('/api/auth/signup')
+    @app.post("/api/auth/signup")
     def signup() -> tuple:
         data = request.get_json(force=True)
-        email = data.get('email')
-        password = data.get('password')
+        email = data.get("email")
+        password = data.get("password")
         if not email or not password:
-            return jsonify({'error': 'invalid'}), 400
+            return jsonify({"error": "invalid"}), 400
         conn = db_utils.connect()
         try:
             cur = conn.execute(
                 text(
-                    'INSERT INTO users (email, password_hash, created_at) VALUES (:e, :p, :c)'
+                    "INSERT INTO users (email, password_hash, created_at) VALUES (:e, :p, :c)"
                 ),
-                {'e': email, 'p': hash_password(password), 'c': datetime.utcnow().isoformat()},
+                {
+                    "e": email,
+                    "p": hash_password(password),
+                    "c": datetime.utcnow().isoformat(),
+                },
             )
             conn.commit()
         except Exception:
             conn.close()
-            return jsonify({'error': 'email exists'}), 400
+            return jsonify({"error": "email exists"}), 400
         user_id = cur.lastrowid
         conn.close()
-        token = create_access_token({'user_id': user_id})
-        return jsonify({'token': token, 'user_id': user_id}), 201
+        token = create_access_token({"user_id": user_id})
+        return jsonify({"token": token, "user_id": user_id}), 201
 
-    @app.post('/api/auth/login')
+    @app.post("/api/auth/login")
     def login() -> tuple:
         data = request.get_json(force=True)
-        email = data.get('email')
-        password = data.get('password')
+        email = data.get("email")
+        password = data.get("password")
         conn = db_utils.connect()
         row = conn.execute(
-            text('SELECT id, password_hash FROM users WHERE email=:e'), {'e': email}
+            text("SELECT id, password_hash FROM users WHERE email=:e"), {"e": email}
         ).fetchone()
         conn.close()
         mapping = row._mapping if row is not None else None
-        if not mapping or not verify_password(password, mapping['password_hash']):
-            return jsonify({'error': 'invalid credentials'}), 401
+        if not mapping or not verify_password(password, mapping["password_hash"]):
+            return jsonify({"error": "invalid credentials"}), 401
 
-        token = create_access_token({'user_id': mapping['id']})
-        return jsonify({'token': token, 'user_id': mapping['id']})
+        token = create_access_token({"user_id": mapping["id"]})
+        return jsonify({"token": token, "user_id": mapping["id"]})
 
-    @app.get('/recalls')
+    @app.get("/recalls")
     def recalls_route():
         return jsonify(fetch_all())
 
-    @app.post('/user-items')
+    @app.post("/user-items")
     def add_item():
         data = request.get_json(force=True)
-        item = data.get('item')
+        item = data.get("item")
         if item:
             USER_ITEMS.append(item)
-        return jsonify({'items': USER_ITEMS})
+        return jsonify({"items": USER_ITEMS})
 
-    @app.get('/alerts')
+    @app.get("/alerts")
     def alerts_route():
         recalls = fetch_all()
         matches = check_user_items.check_user_items(USER_ITEMS, recalls)
         summaries = [
-            generate_summary.generate_summary({'title': 'Recall', 'product': m})
+            generate_summary.generate_summary({"title": "Recall", "product": m})
             for m in matches
         ]
-        return jsonify({'alerts': summaries})
+        return jsonify({"alerts": summaries})
 
-    @app.get('/api/recalls/recent')
+    @app.get("/api/recalls/recent")
     @jwt_required
     def recent_recalls() -> tuple:
         conn = db_utils.connect()
         rows = conn.execute(
             text(
-                'SELECT id, product, hazard, recall_date, source FROM recalls ORDER BY recall_date DESC LIMIT 25'
+                "SELECT id, product, hazard, recall_date, source FROM recalls ORDER BY recall_date DESC LIMIT 25"
             )
         ).fetchall()
         conn.close()
         return jsonify([dict(row._mapping) for row in rows])
 
-    @app.get('/api/recalls/user/<int:user_id>')
+    @app.get("/api/recalls/user/<int:user_id>")
     @jwt_required
     def user_recalls(user_id: int) -> tuple:
         conn = db_utils.connect()
         rows = conn.execute(
             text(
-                'SELECT r.id, r.product, r.hazard, r.recall_date, r.source '
-                'FROM recalls r JOIN products p ON lower(r.product)=lower(p.name) '
-                'WHERE p.user_id=:u ORDER BY r.recall_date DESC'
+                "SELECT r.id, r.product, r.hazard, r.recall_date, r.source "
+                "FROM recalls r JOIN products p ON lower(r.product)=lower(p.name) "
+                "WHERE p.user_id=:u ORDER BY r.recall_date DESC"
             ),
-            {'u': user_id},
+            {"u": user_id},
         ).fetchall()
         conn.close()
 
         return jsonify([dict(row._mapping) for row in rows])
 
-    @app.post('/api/recalls/refresh')
+    @app.get("/api/recalls/vin/<vin>")
+    @jwt_required
+    def vin_recalls(vin: str):
+        if len(vin) != 17 or not vin.isalnum():
+            return jsonify({"error": "invalid VIN"}), 400
+        recalls = get_recalls_for_vin(vin)
+        return jsonify(recalls)
+
+    @app.post("/api/recalls/refresh")
     @jwt_required
     def manual_refresh() -> tuple:
-        if request.headers.get('X-Admin') != 'true':
-            return jsonify({'error': 'unauthorized'}), 403
+        if request.headers.get("X-Admin") != "true":
+            return jsonify({"error": "unauthorized"}), 403
         summary = refresh_recalls()
         return jsonify(summary)
 

--- a/backend/utils/fetch_fda_enforcement.py
+++ b/backend/utils/fetch_fda_enforcement.py
@@ -1,0 +1,61 @@
+"""Fetch drug and device recall data from openFDA."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+import os
+import time
+import requests
+
+DRUG_URL = os.getenv(
+    "FDA_DRUG_URL",
+    "https://api.fda.gov/drug/enforcement.json?search=status:%22Ongoing%22&limit=100",
+)
+DEVICE_URL = os.getenv(
+    "FDA_DEVICE_URL",
+    "https://api.fda.gov/device/enforcement.json?search=status:%22Ongoing%22&limit=100",
+)
+
+
+def _request(url: str, params: Dict | None = None) -> Dict:
+    for attempt in range(3):
+        try:
+            resp = requests.get(url, params=params or {}, timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception:
+            if attempt == 2:
+                raise
+            time.sleep(2**attempt)
+    return {}
+
+
+def _parse(records: List[Dict], source: str) -> List[Dict]:
+    parsed: List[Dict] = []
+    for r in records:
+        recall_id = str(r.get("recall_number", "")).strip()
+        recall_id = "".join(ch for ch in recall_id if ch.isdigit())
+        parsed.append(
+            {
+                "source": source,
+                "id": recall_id,
+                "product": r.get("product_description"),
+                "hazard": r.get("reason_for_recall"),
+                "recall_date": r.get("recall_initiation_date"),
+                "url": r.get("link"),
+                "details": {"code_info": r.get("more_code_info") or r.get("code_info")},
+            }
+        )
+    return parsed
+
+
+def fetch_drug_recalls() -> List[Dict]:
+    data = _request(DRUG_URL)
+    records = data.get("results") or []
+    return _parse(records, "FDA_DRUG")
+
+
+def fetch_device_recalls() -> List[Dict]:
+    data = _request(DEVICE_URL)
+    records = data.get("results") or []
+    return _parse(records, "FDA_DEVICE")

--- a/backend/utils/nhtsa_vin.py
+++ b/backend/utils/nhtsa_vin.py
@@ -1,0 +1,83 @@
+"""VIN-specific recall helpers using the NHTSA Safety API."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+import os
+import time
+import requests
+from sqlalchemy import text
+
+from backend.utils import db as db_utils
+
+VIN_DECODER_URL = os.getenv(
+    "VIN_DECODER_URL",
+    "https://vpic.nhtsa.dot.gov/api/vehicles/DecodeVinValuesExtended/{vin}?format=json",
+)
+RECALL_URL = os.getenv(
+    "NHTSA_RECALL_URL",
+    "https://api.nhtsa.gov/recalls/recallcampaigns?vin={vin}",
+)
+
+
+def _request(url: str) -> Dict:
+    for attempt in range(3):
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception:
+            if attempt == 2:
+                raise
+            time.sleep(2**attempt)
+    return {}
+
+
+def get_recalls_for_vin(vin: str) -> List[Dict]:
+    """Decode a VIN and insert related recalls if new."""
+    info = _request(VIN_DECODER_URL.format(vin=vin))
+    make = model = year = ""
+    results = info.get("Results") or []
+    if results:
+        first = results[0]
+        make = first.get("Make", "")
+        model = first.get("Model", "")
+        year = first.get("ModelYear", "")
+    data = _request(RECALL_URL.format(vin=vin))
+    records = data.get("results") or data.get("Results") or []
+    recalls: List[Dict] = []
+    conn = db_utils.connect()
+    trans = conn.begin()
+    for r in records:
+        rid = str(r.get("NHTSACampaignNumber") or r.get("RecallID"))
+        recall = {
+            "source": "NHTSA_VIN",
+            "id": rid,
+            "product": f"{make} {model} {year}".strip(),
+            "hazard": r.get("Summary"),
+            "recall_date": r.get("ReportReceivedDate") or r.get("RecallDate"),
+            "url": r.get("NHTSAActionNumber"),
+        }
+        existing = conn.execute(
+            text("SELECT id FROM recalls WHERE id=:id AND source=:src"),
+            {"id": recall["id"], "src": recall["source"]},
+        ).fetchone()
+        if not existing:
+            conn.execute(
+                text(
+                    "INSERT INTO recalls (id, product, hazard, recall_date, source, fetched_at) "
+                    "VALUES (:id, :product, :hazard, :date, :source, :f)"
+                ),
+                {
+                    "id": recall["id"],
+                    "product": recall["product"],
+                    "hazard": recall["hazard"],
+                    "date": recall["recall_date"],
+                    "source": recall["source"],
+                    "f": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                },
+            )
+        recalls.append(recall)
+    trans.commit()
+    conn.close()
+    return recalls

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,5 @@ prometheus-client==0.20.0
 celery==5.3.6
 sendgrid==6.11.0
 responses==0.25.0
+requests-mock==1.12.1
 

--- a/tests/test_fda_fetch.py
+++ b/tests/test_fda_fetch.py
@@ -1,0 +1,64 @@
+import requests_mock
+from backend.utils.fetch_fda_enforcement import fetch_drug_recalls, fetch_device_recalls
+from backend.utils.refresh import refresh_recalls
+from backend.db import init_db
+from backend.utils.db import connect
+
+
+def test_fda_enforcement_ingest(tmp_path, monkeypatch):
+    db = tmp_path / "fda.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db}")
+    init_db()
+
+    drug_resp = {
+        "results": [
+            {
+                "recall_number": " D-0001 ",
+                "product_description": "Drug A",
+                "reason_for_recall": "Contamination",
+                "recall_initiation_date": "20240101",
+                "link": "http://drug",
+            }
+        ]
+    }
+    device_resp = {
+        "results": [
+            {
+                "recall_number": " Z-0002 ",
+                "product_description": "Device B",
+                "reason_for_recall": "Faulty",
+                "recall_initiation_date": "20240202",
+                "link": "http://device",
+            }
+        ]
+    }
+    with requests_mock.Mocker() as m:
+        m.get(
+            'https://api.fda.gov/drug/enforcement.json?search=status:"Ongoing"&limit=100',
+            json=drug_resp,
+        )
+        m.get(
+            'https://api.fda.gov/device/enforcement.json?search=status:"Ongoing"&limit=100',
+            json=device_resp,
+        )
+        assert fetch_drug_recalls()[0]["id"] == "0001"
+        assert fetch_device_recalls()[0]["id"] == "0002"
+        # patch other fetchers to return no data
+        import backend.utils.refresh as refresh_mod
+
+        monkeypatch.setattr(refresh_mod, "fetch_cpsc", lambda use_cache=False: [])
+        monkeypatch.setattr(refresh_mod, "fetch_fda", lambda use_cache=False: [])
+        monkeypatch.setattr(refresh_mod, "fetch_nhtsa", lambda use_cache=False: [])
+        monkeypatch.setattr(refresh_mod, "fetch_usda", lambda use_cache=False: [])
+
+        refresh_recalls()
+        refresh_recalls()
+
+    conn = connect()
+    from sqlalchemy import text
+
+    rows = conn.execute(text("SELECT id, source FROM recalls ORDER BY id")).fetchall()
+    conn.close()
+    assert len(rows) == 3
+    sources = {r._mapping["source"] for r in rows}
+    assert {"FDA_DRUG", "FDA_DEVICE"}.issubset(sources)

--- a/tests/test_vin_route.py
+++ b/tests/test_vin_route.py
@@ -1,0 +1,57 @@
+import requests_mock
+from backend.api.app import create_app
+from backend.db import init_db
+from backend.utils.db import connect
+
+
+def test_vin_route(tmp_path, monkeypatch):
+    db = tmp_path / "vin.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db}")
+    init_db()
+
+    vin = "12345678901234567"
+    decode_url = f"https://vpic.nhtsa.dot.gov/api/vehicles/DecodeVinValuesExtended/{vin}?format=json"
+    recall_url = f"https://api.nhtsa.gov/recalls/recallcampaigns?vin={vin}"
+    decode_resp = {"Results": [{"Make": "Ford", "Model": "F150", "ModelYear": "2020"}]}
+    recall_resp = {
+        "results": [
+            {
+                "NHTSACampaignNumber": "20V123",
+                "Summary": "Issue",
+                "ReportReceivedDate": "20240101",
+                "NHTSAActionNumber": "http://recall",
+            }
+        ]
+    }
+
+    with requests_mock.Mocker() as m:
+        m.get(decode_url, json=decode_resp)
+        m.get(recall_url, json=recall_resp)
+        app = create_app()
+        client = app.test_client()
+        login = client.post(
+            "/api/auth/login",
+            json={"email": "user@example.com", "password": "password"},
+        )
+        token = login.get_json()["token"]
+        resp = client.get(
+            f"/api/recalls/vin/{vin}", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data and data[0]["id"] == "20V123"
+
+        # call again to ensure no duplicate insert
+        resp = client.get(
+            f"/api/recalls/vin/{vin}", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 200
+
+    conn = connect()
+    from sqlalchemy import text
+
+    count = conn.execute(
+        text('SELECT COUNT(*) FROM recalls WHERE source="NHTSA_VIN"')
+    ).fetchone()[0]
+    conn.close()
+    assert count == 1


### PR DESCRIPTION
## Summary
- add openFDA enforcement fetcher
- support VIN-specific recall lookup via NHTSA APIs
- wire new fetchers into refresh pipeline
- retry Celery tasks on network errors
- document new endpoints and env vars
- test VIN route and openFDA ingest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685209699bec8321a6ba587c78f053a4