### PR TITLE
Add push notification and unsubscribe support

### DIFF
--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -66,6 +66,29 @@ def create_tables(conn: sqlite3.Connection) -> None:
         )
         """
     )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS push_tokens (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER NOT NULL,
+            token TEXT NOT NULL,
+            added_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(user_id, token),
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS email_unsub_tokens (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER NOT NULL,
+            token TEXT NOT NULL UNIQUE,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )
+        """
+    )
 
 
 def init_db_path(db_path: Path) -> None:

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     Text,
     ForeignKey,
     PrimaryKeyConstraint,
+    UniqueConstraint,
     text,
 )
 
@@ -81,4 +82,26 @@ user_items = Table(
     Column("label", String),
     Column("profile", String, nullable=False, server_default="self"),
     Column("added_at", String, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+)
+
+# FCM push notification tokens
+push_tokens = Table(
+    "push_tokens",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("user_id", Integer, ForeignKey("users.id"), nullable=False),
+    Column("token", String, nullable=False),
+    Column("added_at", String, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    PrimaryKeyConstraint("id"),
+    UniqueConstraint("user_id", "token")
+)
+
+# One-click e-mail unsubscribe tokens
+email_unsub_tokens = Table(
+    "email_unsub_tokens",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("user_id", Integer, ForeignKey("users.id"), nullable=False),
+    Column("token", String, nullable=False, unique=True),
+    Column("created_at", String, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
 )

--- a/backend/utils/priority.py
+++ b/backend/utils/priority.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class RecallProto(Protocol):
+    classification: str | None
+    hazard: str | None
+
+
+def classify_recall(recall: RecallProto) -> str:
+    """Return 'urgent' if recall is high priority else 'digest'."""
+    classification = (recall.classification or "").lower()
+    hazard = (recall.hazard or "").lower()
+    if classification == "class i":
+        return "urgent"
+    keywords = ["fire", "burn", "choking", "death"]
+    if any(word in hazard for word in keywords):
+        return "urgent"
+    return "digest"

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -1,0 +1,16 @@
+from backend.utils.priority import classify_recall
+
+class Obj:
+    def __init__(self, classification=None, hazard=None):
+        self.classification = classification
+        self.hazard = hazard
+
+
+def test_classify_recall_keyword():
+    r = Obj(classification="Class II", hazard="Risk of fire and burns")
+    assert classify_recall(r) == "urgent"
+
+
+def test_classify_recall_default():
+    r = Obj(classification="Class III", hazard="minor defect")
+    assert classify_recall(r) == "digest"


### PR DESCRIPTION
## Summary
- add database tables for push tokens and email unsubscribe tokens
- implement register/delete push token and unsubscribe routes
- include unsubscribe link in email tasks
- provide recall priority classification helper
- test priority logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685215a589cc8321a0c5ff58855e263b