### PR TITLE
Add AI summary and remedy fields

### DIFF
--- a/backend/alembic/versions/0004_summary_and_remedy.py
+++ b/backend/alembic/versions/0004_summary_and_remedy.py
@@ -1,0 +1,23 @@
+"""Add recall summary and remedy updates"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0004'
+down_revision = '0003'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('recalls', sa.Column('summary_text', sa.Text(), nullable=True))
+    op.add_column('recalls', sa.Column('next_steps', sa.Text(), nullable=True))
+    op.add_column(
+        'recalls',
+        sa.Column('remedy_updates', sa.JSON(), server_default='[]', nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('recalls', 'remedy_updates')
+    op.drop_column('recalls', 'next_steps')
+    op.drop_column('recalls', 'summary_text')

--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -49,6 +49,9 @@ def create_tables(conn: sqlite3.Connection) -> None:
             recall_date TEXT,
             source TEXT NOT NULL,
             fetched_at TEXT NOT NULL,
+            summary_text TEXT,
+            next_steps TEXT,
+            remedy_updates JSON DEFAULT '[]',
             PRIMARY KEY (id, source)
         )
         """

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     PrimaryKeyConstraint,
     UniqueConstraint,
     text,
+    JSON,
 )
 
 metadata = MetaData()
@@ -40,6 +41,9 @@ recalls = Table(
     Column("recall_date", String),
     Column("source", String, nullable=False),
     Column("fetched_at", String, nullable=False),
+    Column("summary_text", Text),
+    Column("next_steps", Text),
+    Column("remedy_updates", JSON, server_default="[]"),
     PrimaryKeyConstraint("id", "source"),
 )
 

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -19,5 +19,8 @@ CREATE TABLE recalls (
     recall_date TEXT,
     source TEXT NOT NULL,
     fetched_at TEXT NOT NULL,
+    summary_text TEXT,
+    next_steps TEXT,
+    remedy_updates JSON DEFAULT '[]',
     PRIMARY KEY (id, source)
 );

--- a/backend/utils/ai_summary.py
+++ b/backend/utils/ai_summary.py
@@ -1,0 +1,48 @@
+"""Utilities for AI-powered recall summaries."""
+from __future__ import annotations
+
+import os
+from typing import Tuple
+
+import openai
+
+
+SYSTEM_PROMPT = (
+    "You are a helpful assistant generating brief recall summaries. "
+    "Provide two sentences, no more than 50 words total, explaining the hazard "
+    "in plain English. Then provide a single imperative sentence beginning with "
+    "'Next:' advising the user what to do."
+)
+
+
+def summarize_recall(name: str, hazard: str, classification: str | None = None) -> Tuple[str, str]:
+    """Return a short summary and next steps for a recall."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    user_content = f"Product: {name}\nHazard: {hazard}\nClassification: {classification or ''}"
+    if api_key:
+        client = openai.OpenAI(api_key=api_key)
+        try:
+            resp = client.chat.completions.create(
+                model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
+                messages=[{"role": "system", "content": SYSTEM_PROMPT}, {"role": "user", "content": user_content}],
+                temperature=0.2,
+            )
+            message = resp.choices[0].message.content.strip()
+        except Exception:
+            message = f"{name} may pose a hazard: {hazard}." " Next: Follow official guidance."
+    else:
+        message = f"{name} may pose a hazard: {hazard}." " Next: Follow official guidance."
+    # split into summary and next steps
+    if "Next:" in message:
+        summary_text, next_part = message.split("Next:", 1)
+        summary_text = summary_text.strip()
+        next_steps = "Next:" + next_part.strip()
+    else:
+        lines = [line.strip() for line in message.splitlines() if line.strip()]
+        if lines and lines[-1].lower().startswith("next:"):
+            summary_text = " ".join(lines[:-1])
+            next_steps = lines[-1]
+        else:
+            summary_text = message
+            next_steps = ""
+    return summary_text, next_steps

--- a/tests/test_backend_ai_summary.py
+++ b/tests/test_backend_ai_summary.py
@@ -1,0 +1,35 @@
+from backend.utils.ai_summary import summarize_recall
+
+
+class DummyClient:
+    class Chat:
+        class Completions:
+            @staticmethod
+            def create(*args, **kwargs):
+                class Msg:
+                    content = "This is a hazard summary. Next: Take action."
+
+                class Choice:
+                    message = Msg()
+
+                class Resp:
+                    choices = [Choice()]
+
+                return Resp()
+
+        def __init__(self):
+            self.completions = self.Completions()
+
+    def __init__(self, *args, **kwargs):
+        self.chat = self.Chat()
+
+
+def test_summarize_recall(monkeypatch):
+    import openai
+
+    monkeypatch.setattr(openai, "OpenAI", DummyClient)
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    summary, next_steps = summarize_recall("Widget", "fire", "Class I")
+    assert summary.startswith("This is")
+    assert next_steps.startswith("Next:")
+


### PR DESCRIPTION
## Summary
- expand recalls table with summary & remedy fields
- implement `ai_summary.summarize_recall`
- generate summaries during recall refresh
- provide alembic migration
- test summary helper

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852179a54608321b349e25c56e90bbb