### PR TITLE
Add remedy progress tracking and timeline view

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -135,7 +135,6 @@ def create_app() -> Flask:
         recalls = get_recalls_for_vin(vin)
         return jsonify(recalls)
 
-
     @app.get("/api/check/<upc>")
     def check_upc(upc: str):
         if not upc.isdigit():
@@ -164,6 +163,20 @@ def create_app() -> Flask:
             }
         )
 
+    @app.get("/api/recall/<rid>")
+    @jwt_required
+    def recall_detail(rid: str):
+        conn = db_utils.connect()
+        row = conn.execute(
+            text(
+                "SELECT id, product, hazard, summary_text, next_steps, remedy_updates FROM recalls WHERE id=:r"
+            ),
+            {"r": rid},
+        ).fetchone()
+        conn.close()
+        if not row:
+            return jsonify({"error": "not found"}), 404
+        return jsonify(dict(row._mapping))
 
     @app.post("/api/recalls/refresh")
     @jwt_required

--- a/backend/api/items.py
+++ b/backend/api/items.py
@@ -4,13 +4,13 @@ from backend.utils.auth import jwt_required, get_jwt_subject
 from backend.utils.session import SessionLocal
 from backend.db.models import user_items
 
-bp = Blueprint('items', __name__)
+bp = Blueprint("items", __name__)
 
 
 def lookup_upc(db, upc: str) -> dict:
     info = db.execute(text("PRAGMA table_info(recalls)")).fetchall()
     cols = {r[1] for r in info}
-    query = "SELECT id, product, hazard"
+    query = "SELECT id, product, hazard, remedy_updates"
     query += ", url" if "url" in cols else ", '' as url"
     query += " FROM recalls WHERE product=:p"
     params = {"p": upc}
@@ -25,50 +25,59 @@ def lookup_upc(db, upc: str) -> dict:
             "product_name": m["product"],
             "hazard": m["hazard"],
             "url": m["url"],
+            "update_count": len(m["remedy_updates"] or []),
         }
     return {"status": "safe"}
 
 
-@bp.get('/api/items')
+@bp.get("/api/items")
 @jwt_required
 def list_items():
-    user_id = get_jwt_subject()['user_id']
+    user_id = get_jwt_subject()["user_id"]
     with SessionLocal() as db:
-        rows = db.execute(user_items.select().where(user_items.c.user_id == user_id)).fetchall()
+        rows = db.execute(
+            user_items.select().where(user_items.c.user_id == user_id)
+        ).fetchall()
         items = []
         for r in rows:
             item = dict(r._mapping)
-            status = lookup_upc(db, item['upc'])
-            item['status'] = status['status']
+            status = lookup_upc(db, item["upc"])
+            item["status"] = status["status"]
+            if "update_count" in status:
+                item["update_count"] = status["update_count"]
             items.append(item)
         return jsonify(items)
 
 
-@bp.post('/api/items')
+@bp.post("/api/items")
 @jwt_required
 def add_item():
     data = request.get_json(force=True)
-    upc = data.get('upc')
+    upc = data.get("upc")
     if not upc:
-        return jsonify({'error': 'upc required'}), 400
-    label = data.get('label')
-    profile = data.get('profile') or 'self'
-    user_id = get_jwt_subject()['user_id']
+        return jsonify({"error": "upc required"}), 400
+    label = data.get("label")
+    profile = data.get("profile") or "self"
+    user_id = get_jwt_subject()["user_id"]
     with SessionLocal() as db:
         res = db.execute(
-            user_items.insert().values(user_id=user_id, upc=upc, label=label, profile=profile)
+            user_items.insert().values(
+                user_id=user_id, upc=upc, label=label, profile=profile
+            )
         )
         db.commit()
-        return jsonify({'id': res.lastrowid}), 201
+        return jsonify({"id": res.lastrowid}), 201
 
 
-@bp.delete('/api/items/<int:item_id>')
+@bp.delete("/api/items/<int:item_id>")
 @jwt_required
 def delete_item(item_id: int):
-    user_id = get_jwt_subject()['user_id']
+    user_id = get_jwt_subject()["user_id"]
     with SessionLocal() as db:
         db.execute(
-            user_items.delete().where(user_items.c.id == item_id, user_items.c.user_id == user_id)
+            user_items.delete().where(
+                user_items.c.id == item_id, user_items.c.user_id == user_id
+            )
         )
         db.commit()
-        return jsonify({'status': 'ok'})
+        return jsonify({"status": "ok"})

--- a/backend/utils/remedy.py
+++ b/backend/utils/remedy.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+
+def extract_remedy(html: str) -> str | None:
+    """Return remedy text from recall HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    heading = soup.find(
+        lambda t: t.name in {"h1", "h2", "h3", "h4"}
+        and "remedy" in t.get_text(strip=True).lower()
+    )
+    if heading:
+        p = heading.find_next("p")
+        if p:
+            text = p.get_text(strip=True)
+            if text:
+                return text
+
+    strong = soup.find(
+        lambda t: t.name in {"b", "strong"}
+        and "remedy" in t.get_text(strip=True).lower()
+    )
+    if strong:
+        text = strong.parent.get_text(strip=True)
+        if text:
+            return text.replace(strong.get_text(strip=True), "").strip()
+
+    return None

--- a/frontend/__tests__/__snapshots__/timeline.test.jsx.snap
+++ b/frontend/__tests__/__snapshots__/timeline.test.jsx.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`timeline snapshot 1`] = `
+<DocumentFragment>
+  <div>
+    <h2>
+      Widget
+    </h2>
+    <p>
+      Fire
+    </p>
+    <div
+      aria-label="timeline"
+    >
+      <div
+        style="border-left: 2px solid rgb(204, 204, 204); margin-left: 1em; padding-left: 1em;"
+      >
+        <div>
+          2024-01-01
+        </div>
+        <p>
+          Initial
+        </p>
+      </div>
+      <div
+        style="border-left: 2px solid rgb(204, 204, 204); margin-left: 1em; padding-left: 1em;"
+      >
+        <div>
+          2024-02-01
+        </div>
+        <p>
+          Follow-up
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/timeline.test.jsx
+++ b/frontend/__tests__/timeline.test.jsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+jest.mock('next/router', () => ({ useRouter: () => ({ query: { id: '1' } }) }));
+
+import RecallDetail from '../pages/recall/[id].jsx';
+import { AuthContext } from '../components/AuthContext.jsx';
+
+test('timeline snapshot', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    json: async () => ({
+      product: 'Widget',
+      hazard: 'Fire',
+      remedy_updates: [
+        { time: '2024-01-01', text: 'Initial' },
+        { time: '2024-02-01', text: 'Follow-up' }
+      ]
+    })
+  });
+  const { asFragment, findByText } = render(
+    <AuthContext.Provider value={{ token: 't' }}>
+      <RecallDetail />
+    </AuthContext.Provider>
+  );
+  await findByText('Widget');
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/frontend/pages/dashboard.jsx
+++ b/frontend/pages/dashboard.jsx
@@ -34,6 +34,12 @@ export default function Dashboard() {
             {r.hazard}
           </Badge>
           <Badge>{r.source.toUpperCase()}</Badge>
+          {r.summary_text && (
+            <Text mt={2} fontSize="sm">{r.summary_text}</Text>
+          )}
+          {r.next_steps && (
+            <Text mt={2} fontSize="sm" color="green.700">{r.next_steps}</Text>
+          )}
           <Text mt={2} fontSize="sm">
             {r.recall_date}
           </Text>

--- a/frontend/pages/mystuff.jsx
+++ b/frontend/pages/mystuff.jsx
@@ -77,6 +77,9 @@ export default function MyStuff() {
             {list.map((it) => (
               <li key={it.id}>
                 {it.label || it.upc} - {it.status === 'recalled' ? '⚠️ Recalled' : '✅ Safe'}
+                {it.update_count > 0 && (
+                  <span data-testid="update-badge"> ({it.update_count})</span>
+                )}
                 <button onClick={() => remove(it.id)}>Delete</button>
               </li>
             ))}

--- a/frontend/pages/recall/[id].jsx
+++ b/frontend/pages/recall/[id].jsx
@@ -1,0 +1,35 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState, useContext } from 'react';
+import { AuthContext } from '../../components/AuthContext.jsx';
+
+export default function RecallDetail() {
+  const router = useRouter();
+  const { token } = useContext(AuthContext);
+  const { id } = router.query;
+  const [recall, setRecall] = useState(null);
+
+  useEffect(() => {
+    if (!id || !token) return;
+    fetch(`/api/recall/${id}`, { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => r.json())
+      .then((data) => setRecall(data))
+      .catch(() => {});
+  }, [id, token]);
+
+  if (!recall) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2>{recall.product}</h2>
+      <p>{recall.hazard}</p>
+      <div aria-label="timeline">
+        {recall.remedy_updates && recall.remedy_updates.map((u, i) => (
+          <div key={i} style={{ borderLeft: '2px solid #ccc', marginLeft: '1em', paddingLeft: '1em' }}>
+            <div>{u.time}</div>
+            <p>{u.text}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/tests/test_remedy_updates.py
+++ b/tests/test_remedy_updates.py
@@ -1,0 +1,46 @@
+from backend.tasks import poll_remedy_updates
+from backend.db import init_db
+from backend.utils.db import connect
+from sqlalchemy import text
+import requests
+import json
+
+
+def test_poll_remedy_updates(tmp_path, monkeypatch):
+    db = tmp_path / "rem.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db}")
+    init_db()
+    conn = connect()
+    conn.execute(text("ALTER TABLE recalls ADD COLUMN url TEXT"))
+    conn.execute(
+        text(
+            "INSERT INTO recalls (id, product, hazard, recall_date, source, fetched_at, remedy_updates, url) "
+            "VALUES ('r1','Widget','Fire','2025-05-30','cpsc','2025-05-30','[]','http://x')"
+        )
+    )
+    conn.execute(
+        text("INSERT INTO sent_notifications (user_id, recall_id) VALUES (1,'r1')")
+    )
+    conn.commit()
+    conn.close()
+
+    class FakeResp:
+        text = "<h2>Remedy</h2><p>Do this</p>"
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(requests, "get", lambda *a, **k: FakeResp())
+
+    poll_remedy_updates()
+
+    conn = connect()
+    row = conn.execute(
+        text("SELECT remedy_updates FROM recalls WHERE id='r1'")
+    ).fetchone()
+    data = row[0]
+    updates = data if isinstance(data, list) else json.loads(data)
+    assert len(updates) == 1
+    count = conn.execute(text("SELECT COUNT(*) FROM alerts")).fetchone()[0]
+    conn.close()
+    assert count == 1


### PR DESCRIPTION
## Summary
- track remedy updates with new Celery task
- expose recall details endpoint
- surface summary and next steps on dashboard
- show update badges on My Stuff
- add recall detail timeline page
- notify users when remedy info changes
- tests for remedy polling and timeline component

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521a01e1948321a77e4bc43bf573e6